### PR TITLE
Rename 'contactid' in query to 'guid' to match endpoint requirements

### DIFF
--- a/src/php/Lookup/UserAgent.php
+++ b/src/php/Lookup/UserAgent.php
@@ -26,7 +26,7 @@ class UserAgent
         $strURL = sprintf(self::c_URL_Agent, $strUserAgent);
         $arrQuery = [
             'accounturl' => $strAccountUrl,
-            'contactId'  => $guidContactId
+            'contactid'  => $guidContactId
         ];
 
         try {

--- a/src/php/Lookup/UserAgent.php
+++ b/src/php/Lookup/UserAgent.php
@@ -26,7 +26,7 @@ class UserAgent
         $strURL = sprintf(self::c_URL_Agent, $strUserAgent);
         $arrQuery = [
             'accounturl' => $strAccountUrl,
-            'guid'       => $guidContactId
+            'contactId'       => $guidContactId
         ];
 
         try {

--- a/src/php/Lookup/UserAgent.php
+++ b/src/php/Lookup/UserAgent.php
@@ -26,7 +26,7 @@ class UserAgent
         $strURL = sprintf(self::c_URL_Agent, $strUserAgent);
         $arrQuery = [
             'accounturl' => $strAccountUrl,
-            'contactId'       => $guidContactId
+            'contactId'  => $guidContactId
         ];
 
         try {

--- a/src/php/Lookup/UserAgent.php
+++ b/src/php/Lookup/UserAgent.php
@@ -26,7 +26,7 @@ class UserAgent
         $strURL = sprintf(self::c_URL_Agent, $strUserAgent);
         $arrQuery = [
             'accounturl' => $strAccountUrl,
-            'contactid'  => $guidContactId
+            'guid'       => $guidContactId
         ];
 
         try {

--- a/test/php/Lookup/UserAgentTest.php
+++ b/test/php/Lookup/UserAgentTest.php
@@ -32,7 +32,7 @@ class UserAgentTest
         $guidContactId = md5(1);
         $arrQuery = [
             'accounturl' => null,
-            'contactid' => null
+            'guid' => null
         ];
         $strURL = sprintf(UserAgent::c_URL_Agent, urlencode($strUserAgent));
         $userAgentInstance = UserAgent::getInstance($strBaseUri, $strApiKey);

--- a/test/php/Lookup/UserAgentTest.php
+++ b/test/php/Lookup/UserAgentTest.php
@@ -32,7 +32,7 @@ class UserAgentTest
         $guidContactId = md5(1);
         $arrQuery = [
             'accounturl' => null,
-            'guid' => null
+            'contactId'  => null
         ];
         $strURL = sprintf(UserAgent::c_URL_Agent, urlencode($strUserAgent));
         $userAgentInstance = UserAgent::getInstance($strBaseUri, $strApiKey);

--- a/test/php/Lookup/UserAgentTest.php
+++ b/test/php/Lookup/UserAgentTest.php
@@ -32,7 +32,7 @@ class UserAgentTest
         $guidContactId = md5(1);
         $arrQuery = [
             'accounturl' => null,
-            'contactId'  => null
+            'contactid'  => null
         ];
         $strURL = sprintf(UserAgent::c_URL_Agent, urlencode($strUserAgent));
         $userAgentInstance = UserAgent::getInstance($strBaseUri, $strApiKey);


### PR DESCRIPTION
We need to rename the query so it matches the endpoint requirements, otherwise guid will log as null