### PR TITLE
Use access tokens instead of API keys

### DIFF
--- a/src/php/Interface/Singleton.php
+++ b/src/php/Interface/Singleton.php
@@ -18,7 +18,7 @@ interface InterfaceSingleton
     **/
     public static function getInstance(
         $strURL     = null,
-        $strApiKey  = null
+        $strAccessToken  = null
     );
 
     /**

--- a/src/php/Traits/Singleton.php
+++ b/src/php/Traits/Singleton.php
@@ -18,7 +18,7 @@ use CanddiAi\Singleton\InterfaceSingleton;
 trait TraitSingleton
 {
     private $_strURL;
-    private $_strAPIKey;
+    private $_strAccessToken;
 
     /**
      * Prevent instantiation and cloning
@@ -26,17 +26,17 @@ trait TraitSingleton
     **/
     final protected function __construct(
         $strURL,
-        $strApiKey
+        $strAccessToken
     )
     {
-        if (empty($strURL) || empty($strApiKey)) {
+        if (empty($strURL) || empty($strAccessToken)) {
             throw new \Exception(
                 "Unable to create instance - Missing URL OR Key"
             );
         }
 
         $this->_strURL      = $strURL;
-        $this->_strAPIKey   = $strApiKey;
+        $this->_strAccessToken   = $strAccessToken;
     }
 
     final protected function __clone()
@@ -58,19 +58,28 @@ trait TraitSingleton
     **/
     public static function getInstance(
         $strURL     = null,
-        $strApiKey  = null
+        $strAccessToken  = null
     )
     {
         if (is_null(static::$_locater)) {
             static::$_locater   = new static(
                 $strURL,
-                $strApiKey
+                $strAccessToken
             );
         }
+
+        static::$_locater->setAccessToken(
+            $strAccessToken
+        );
 
         return static::$_locater;
     }
 
+    private function setAccessToken(
+        $strAccessToken = null
+    ) {
+        $this->_strAccessToken = $strAccessToken;
+    }
     /**
      * This method is used for testing
      *  @param: $locator    - this is mainly for testing
@@ -106,7 +115,7 @@ trait TraitSingleton
     {
         self::$_guzzleConnection    = $guzzleConnection;
     }
-    protected static function _getGuzzle($strBaseUri, $strApiKey)
+    protected static function _getGuzzle($strBaseUri, $strAccessToken)
     {
         if (!self::$_guzzleConnection) {
             $arrDefaults                = [
@@ -116,7 +125,7 @@ trait TraitSingleton
                 'headers'               => [
                     'Accept'            => 'application/json',
                     'Accept-Encoding'   => 'gzip, deflate',
-                    'x-api-key'         => $strApiKey
+                    'Authorization'         => $strAccessToken
                 ],
                 "verify"                => false
             ];
@@ -129,7 +138,7 @@ trait TraitSingleton
         Array $arrQuery                 = []
     )
     {
-        $guzzleConnection = self::_getGuzzle($this->_strURL, $this->_strAPIKey);
+        $guzzleConnection = self::_getGuzzle($this->_strURL, $this->_strAccessToken);
 
         $response                   = $guzzleConnection
             ->request(

--- a/test/functionalTest/Lookup/Company.php
+++ b/test/functionalTest/Lookup/Company.php
@@ -18,7 +18,7 @@ class FunctionalTest_Company
         $strAccountURL = 'anAccount';
         $guidContactId = md5(1);
 
-        $instance = Company::getInstance($this->_strBaseUri, $this->_strApiKey);
+        $instance = Company::getInstance($this->_strBaseUri, $this->_strAccessToken);
 
         $response = $instance->lookupHost($strHost, $strAccountURL, $guidContactId);
 
@@ -30,7 +30,7 @@ class FunctionalTest_Company
         $strAccountURL = 'anAccount';
         $guidContactId = md5(1);
 
-        $instance = Company::getInstance($this->_strBaseUri, $this->_strApiKey);
+        $instance = Company::getInstance($this->_strBaseUri, $this->_strAccessToken);
 
         $response = $instance->lookupIP($strIP, $strAccountURL, $guidContactId);
 
@@ -42,7 +42,7 @@ class FunctionalTest_Company
         $strAccountURL = 'anAccount';
         $guidContactId = md5(1);
 
-        $instance = Company::getInstance($this->_strBaseUri, $this->_strApiKey);
+        $instance = Company::getInstance($this->_strBaseUri, $this->_strAccessToken);
 
         $response = $instance->lookupName($strName, $strAccountURL, $guidContactId);
 
@@ -54,7 +54,7 @@ class FunctionalTest_Company
         $strAccountURL = 'anAccount';
         $guidContactId = md5(1);
 
-        $instance = Company::getInstance($this->_strBaseUri, $this->_strApiKey);
+        $instance = Company::getInstance($this->_strBaseUri, $this->_strAccessToken);
 
         $response = $instance->lookupCompanyName($strName, $strAccountURL, $guidContactId);
 

--- a/test/functionalTest/Lookup/NormalizeName.php
+++ b/test/functionalTest/Lookup/NormalizeName.php
@@ -9,14 +9,14 @@ namespace CanddiAi\Lookup;
 class FunctionalTest_NormalizeName
     extends \CanddiAi\Functional_TestCase
 {
-    private $_strBaseUri = 'https://ip.canddi.ai';
-    private $_strApiKey = '';
+    private $_strBaseUri = '';
+    private $_strAccessToken = '';
 
     public function testNormalizeName()
     {
         $strName = 'Logan White';
 
-        $instance = NormalizeName::getInstance($this->_strBaseUri, $this->_strApiKey);
+        $instance = NormalizeName::getInstance($this->_strBaseUri, $this->_strAccessToken);
 
         $response = $instance->normalizeName($strName);
 

--- a/test/functionalTest/Lookup/Person.php
+++ b/test/functionalTest/Lookup/Person.php
@@ -9,7 +9,7 @@ namespace CanddiAi\Lookup;
 class FunctionalTest_Person
     extends \CanddiAi\Functional_TestCase
 {
-    private $_strApiKey = '';
+    private $_strAccessToken = '';
     private $_strBaseUri = '';
 
     public function testLookupEmail()
@@ -18,7 +18,7 @@ class FunctionalTest_Person
         $strAccountURL = 'anAccount';
         $guidContactId = md5(1);
 
-        $instance = Person::getInstance($this->_strBaseUri, $this->_strApiKey);
+        $instance = Person::getInstance($this->_strBaseUri, $this->_strAccessToken);
 
         $response = $instance->lookupEmail($strEmail, $strAccountURL, $guidContactId);
 

--- a/test/functionalTest/Lookup/UserAgent.php
+++ b/test/functionalTest/Lookup/UserAgent.php
@@ -5,7 +5,7 @@ namespace CanddiAi\Lookup;
 class FunctionalTest_UserAgent
     extends \CanddiAi\Functional_TestCase
 {
-    private $_strAPIKey = "";
+    private $_strAccessToken = '';
     private $_strBaseUri = "";
 
     public function testUserAgent()
@@ -114,7 +114,7 @@ class FunctionalTest_UserAgent
 
         $instance = UserAgent::getInstance(
             $this->_strBaseUri,
-            $this->_strAPIKey
+            $this->_strAccessToken
         );
 
         for ($strUserAgent = 0; $strUserAgent < sizeof($arrUserAgents); $strUserAgent++)

--- a/test/php/Lookup/AddressTest.php
+++ b/test/php/Lookup/AddressTest.php
@@ -22,11 +22,11 @@ class AddressTest
         ];
 
         $strBaseUri = 'baseuri.com';
-        $strApiKey = 'api_key_v4387yt876y745';
+        $strAccessToken = md5(1);
         $strAddress = $arrAddressData["FormattedAddress"];
 
         $strURL = sprintf(Address::c_URL_Address, rawurlencode($strAddress));
-        $addressInstance = Address::getInstance($strBaseUri, $strApiKey);
+        $addressInstance = Address::getInstance($strBaseUri, $strAccessToken);
         $mockResponse = \Mockery::mock('GuzzleHttp\Psr7\Response')
             ->shouldReceive('getStatusCode')
             ->once()

--- a/test/php/Lookup/CompanyTest.php
+++ b/test/php/Lookup/CompanyTest.php
@@ -9,7 +9,7 @@ class CompanyTest
     public function testLookupCompanyName()
     {
         $strBaseUri = 'baseuri.com';
-        $strApiKey = 'api_key_v4387yt876y745';
+        $strAccessToken = md5(1);
         $strName = 'CANDD/i';
         $strAccountURL = 'anAccount';
         $guidContactId = md5(1);
@@ -20,7 +20,7 @@ class CompanyTest
             'cburl'         => '',
             'cboptions'     => '{}'
         ];
-        $companyInstance = Company::getInstance($strBaseUri, $strApiKey);
+        $companyInstance = Company::getInstance($strBaseUri, $strAccessToken);
         $mockResponse = \Mockery::mock('GuzzleHttp\Psr7\Response')
             ->shouldReceive('getStatusCode')
             ->once()
@@ -50,7 +50,7 @@ class CompanyTest
     public function testLookupCompanyName_WithCallback()
     {
         $strBaseUri = 'baseuri.com';
-        $strApiKey = 'api_key_v4387yt876y745';
+        $strAccessToken = md5(1);
         $strName = 'CANDDi';
         $strAccountURL = 'anAccount';
         $guidContactId = md5(1);
@@ -67,7 +67,7 @@ class CompanyTest
             'cburl'         => $strCallback,
             'cboptions'     => '{\"headers\":{\"my\":\"header\"}}'
         ];
-        $companyInstance = Company::getInstance($strBaseUri, $strApiKey);
+        $companyInstance = Company::getInstance($strBaseUri, $strAccessToken);
         $mockResponse = \Mockery::mock('GuzzleHttp\Psr7\Response')
             ->shouldReceive('getStatusCode')
             ->once()
@@ -97,7 +97,7 @@ class CompanyTest
     public function testLookupHost()
     {
         $strBaseUri = 'baseuri.com';
-        $strApiKey = 'api_key_v4387yt876y745';
+        $strAccessToken = md5(1);
         $strHostname = 'hostname.com';
         $strAccountURL = 'anAccount';
         $guidContactId = md5(1);
@@ -108,7 +108,7 @@ class CompanyTest
             'cburl'         => '',
             'cboptions'     => '{}'
         ];
-        $companyInstance = Company::getInstance($strBaseUri, $strApiKey);
+        $companyInstance = Company::getInstance($strBaseUri, $strAccessToken);
         $mockResponse = \Mockery::mock('GuzzleHttp\Psr7\Response')
             ->shouldReceive('getStatusCode')
             ->once()
@@ -142,7 +142,7 @@ class CompanyTest
     public function testLookupIP()
     {
         $strBaseUri = 'baseuri.com';
-        $strApiKey = 'api_key_v4387yt876y745';
+        $strAccessToken = md5(1);
         $intIP = 12345;
         $strAccountURL = 'anAccount';
         $guidContactId = md5(1);
@@ -153,7 +153,7 @@ class CompanyTest
             'cburl'         => '',
             'cboptions'     => '{}'
         ];
-        $companyInstance = Company::getInstance($strBaseUri, $strApiKey);
+        $companyInstance = Company::getInstance($strBaseUri, $strAccessToken);
         $mockResponse = \Mockery::mock('GuzzleHttp\Psr7\Response')
             ->shouldReceive('getStatusCode')
             ->once()
@@ -187,7 +187,7 @@ class CompanyTest
     public function testLookupName()
     {
         $strBaseUri = 'baseuri.com';
-        $strApiKey = 'api_key_v4387yt876y745';
+        $strAccessToken = md5(1);
         $strName = 'CANDDi';
         $strAccountURL = 'anAccount';
         $guidContactId = md5(1);
@@ -198,7 +198,7 @@ class CompanyTest
             'cburl'         => '',
             'cboptions'     => '{}'
         ];
-        $companyInstance = Company::getInstance($strBaseUri, $strApiKey);
+        $companyInstance = Company::getInstance($strBaseUri, $strAccessToken);
         $mockResponse = \Mockery::mock('GuzzleHttp\Psr7\Response')
             ->shouldReceive('getStatusCode')
             ->once()
@@ -232,7 +232,7 @@ class CompanyTest
     public function testLookups_Fail()
     {
         $strBaseUri = 'baseuri.com';
-        $strApiKey = 'api_key_v4387yt876y745';
+        $strAccessToken = md5(1);
         $strAccountURL = 'anAccount';
         $guidContactId = md5(1);
         $arrQuery           = [
@@ -271,7 +271,7 @@ class CompanyTest
             ->mock();
 
         Company::injectGuzzle($mockGuzzle);
-        $lookupCompany = Company::getInstance($strBaseUri, $strApiKey);
+        $lookupCompany = Company::getInstance($strBaseUri, $strAccessToken);
 
         $returnedException = null;
 

--- a/test/php/Lookup/NormalizeNameTest.php
+++ b/test/php/Lookup/NormalizeNameTest.php
@@ -12,11 +12,11 @@ class NormalizeNameTest
         $strName = 'Logan White';
 
         $strBaseUri = 'https://ip.canddi.ai';
-        $strApiKey = md5(1);
+        $strAccessToken = md5(1);
 
         $strURL = sprintf(NormalizeName::c_URL_NORMALIZE, $strName);
 
-        $normalizeNameInstance = NormalizeName::getInstance($strBaseUri, $strApiKey);
+        $normalizeNameInstance = NormalizeName::getInstance($strBaseUri, $strAccessToken);
 
         $responseBody = [
             "status" => "200",
@@ -65,12 +65,12 @@ class NormalizeNameTest
     public function testNormalizeNameIncorrectName() {
         $strName = 'fakename';
 
-        $strBaseUri = 'https://ip.canddi.ai';
-        $strApiKey = '5RPIBLH2t61mJb6BRUjGa4Rm5TB56Xp22YAFaB8o';
+        $strBaseUri = 'baseuri.com';
+        $strAccessToken = md5(1);
 
         $strURL = sprintf(NormalizeName::c_URL_NORMALIZE, $strName);
 
-        $normalizeNameInstance = NormalizeName::getInstance($strBaseUri, $strApiKey);
+        $normalizeNameInstance = NormalizeName::getInstance($strBaseUri, $strAccessToken);
 
         $responseBody = [
             "status" => "200",

--- a/test/php/Lookup/PersonTest.php
+++ b/test/php/Lookup/PersonTest.php
@@ -9,7 +9,7 @@ class PersonTest
     public function testLookupEmail()
     {
         $strBaseUri = 'baseuri.com';
-        $strApiKey = 'api_key_v4387yt876y745';
+        $strAccessToken = md5(1);
         $strEmail = 'tim@canddi.com';
         $strAccountURL = 'anAccount';
         $guidContactId = md5(1);
@@ -18,7 +18,7 @@ class PersonTest
             'accounturl'    => $strAccountURL,
             'contactid'     => $guidContactId
         ];
-        $companyInstance = Person::getInstance($strBaseUri, $strApiKey);
+        $companyInstance = Person::getInstance($strBaseUri, $strAccessToken);
         $mockResponse = \Mockery::mock('GuzzleHttp\Psr7\Response')
             ->shouldReceive('getStatusCode')
             ->once()
@@ -49,7 +49,7 @@ class PersonTest
     public function testLookups_Fail()
     {
         $strBaseUri = 'baseuri.com';
-        $strApiKey = 'api_key_v4387yt876y745';
+        $strAccessToken = md5(1);
         $strAccountURL = 'anAccount';
         $guidContactId = md5(1);
         $arrQuery           = [
@@ -84,7 +84,7 @@ class PersonTest
             ->mock();
 
         Person::injectGuzzle($mockGuzzle);
-        $lookupCompany = Person::getInstance($strBaseUri, $strApiKey);
+        $lookupCompany = Person::getInstance($strBaseUri, $strAccessToken);
 
         $returnedException = null;
 

--- a/test/php/Lookup/UserAgentTest.php
+++ b/test/php/Lookup/UserAgentTest.php
@@ -26,7 +26,7 @@ class UserAgentTest
             "DeviceVersion" => "0.0"
         ];
         $strBaseUri = 'baseuri.com';
-        $strApiKey = 'api_key_v4387yt876y745';
+        $strAccessToken = md5(1);
         $strUserAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.86 Safari/537.36';
         $strAccountURL = 'anAccount';
         $guidContactId = md5(1);
@@ -35,7 +35,7 @@ class UserAgentTest
             'contactid' => null
         ];
         $strURL = sprintf(UserAgent::c_URL_Agent, rawurlencode($strUserAgent));
-        $userAgentInstance = UserAgent::getInstance($strBaseUri, $strApiKey);
+        $userAgentInstance = UserAgent::getInstance($strBaseUri, $strAccessToken);
         $mockResponse = \Mockery::mock('GuzzleHttp\Psr7\Response')
             ->shouldReceive('getStatusCode')
             ->once()


### PR DESCRIPTION
# Do we need to deploy separate endpoint first?
see pr https://github.com/Canddi/canddi/pull/5095

TODO: Update canddi to handle canddi_ai



We are now using access tokens to authenticate endpoints instead of an API key