### PR TITLE
Throw 404 on bad response

### DIFF
--- a/src/php/Lookup/NormalizeName.php
+++ b/src/php/Lookup/NormalizeName.php
@@ -33,6 +33,10 @@ class NormalizeName
             $arrResponse    = $this->_callEndpoint(
                 $strURL
             );
+
+            if ($arrResponse === NULL) {
+                throw new \Exception('404 Not Found');
+            }
         } catch(\Exception $e) {
             throw new \Exception(
                 "Service:NormalizeName returned error for ($strName) " .


### PR DESCRIPTION
If we receive null from normalizeName then we throw a '404 Not Found', this prevents our fatal error from passing null into Response\NormalizeName

We handle 404s already, as we should be returning them in other cases