### PR TITLE
CS-11933 - Person LinkedIn response

### DIFF
--- a/src/php/Lookup/Person.php
+++ b/src/php/Lookup/Person.php
@@ -19,6 +19,7 @@ class Person
     use TraitSingleton;
 
     const c_URL_Person  = 'person/email/%s';
+    const c_URL_LinkedIn = 'person/linkedin/%s';
     /**
      * This calls the https://api.canddi.net/person/email/[emailaddress]
      * end point and returns an array of data
@@ -56,5 +57,37 @@ class Person
         }
 
         return new Response\Person($arrResponse);
+    }
+
+    public function lookupLinkedIn(
+        $strLinkedInUsername,
+        $strAccountURL = null,
+        $guidContactId = null,
+        $strCallbackUrl = null,
+        $arrCallbackOptions = []
+    )
+    {
+        $strURL = sprintf(self::c_URL_LinkedIn, $strLinkedInUsername);
+        $arrQuery           = [
+            'accounturl'    => $strAccountURL,
+            'contactid'     => $guidContactId,
+            'cburl'         => $strCallbackUrl,
+            'cboptions'     => str_replace('"', '\\"', json_encode($arrCallbackOptions,JSON_FORCE_OBJECT))
+        ];
+
+        try {
+            $arrResponse = $this->_callEndpoint(
+                $strURL,
+                $arrQuery
+            );
+        } catch(\Exception $e) {
+            throw new \Exception(
+                "Service:Person:LinkedIn returned error for ($strLinkedInUsername) ".
+                " on Account ($strAccountURL), Contact ($guidContactId) ".
+                $e->getMessage()
+            );
+        }
+
+        return new Response\PersonLinkedIn($arrResponse);
     }
 }

--- a/src/php/Lookup/Response/Item/Role.php
+++ b/src/php/Lookup/Response/Item/Role.php
@@ -1,0 +1,61 @@
+<?php
+namespace CanddiAi\Lookup\Response\Item;
+
+use CanddiAi\Traits\GetArrayValue as NS_traitArrayValue;
+
+class Role
+{
+    const KEY_PRIMARY   = 'IsPrimary';
+    const KEY_TITLE     = 'Title';
+    const KEY_START     = 'StartDate';
+    const KEY_END       = 'EndDate';
+
+    use NS_traitArrayValue;
+
+    private $_arrResponse;
+
+    public function __construct(Array $arrResponse)
+    {
+        $this->_arrResponse = $arrResponse;
+    }
+    public function bPrimary()
+    {
+        return $this->_getArrayValue(
+            $this->_arrResponse,
+            [
+                self::KEY_PRIMARY
+            ],
+            false
+        );
+    }
+    public function getTitle()
+    {
+        return $this->_getArrayValue(
+            $this->_arrResponse,
+            [
+                self::KEY_TITLE
+            ],
+            ""
+        );
+    }
+    public function getStartDate()
+    {
+        return $this->_getArrayValue(
+            $this->_arrResponse,
+            [
+                self::KEY_START
+            ],
+            ""
+        );
+    }
+    public function getEndDate()
+    {
+        return $this->_getArrayValue(
+            $this->_arrResponse,
+            [
+                self::KEY_END
+            ],
+            ""
+        );
+    }
+}

--- a/src/php/Lookup/Response/Item/Role.php
+++ b/src/php/Lookup/Response/Item/Role.php
@@ -7,6 +7,7 @@ class Role
 {
     const KEY_PRIMARY   = 'IsPrimary';
     const KEY_TITLE     = 'Title';
+    const KEY_NAME      = 'CompanyName';
     const KEY_START     = 'StartDate';
     const KEY_END       = 'EndDate';
 
@@ -34,6 +35,16 @@ class Role
             $this->_arrResponse,
             [
                 self::KEY_TITLE
+            ],
+            ""
+        );
+    }
+    public function getName()
+    {
+        return $this->_getArrayValue(
+            $this->_arrResponse,
+            [
+                self::KEY_NAME
             ],
             ""
         );

--- a/src/php/Lookup/Response/Person.php
+++ b/src/php/Lookup/Response/Person.php
@@ -4,6 +4,7 @@
  * https://api.canddi.net
  *
  * @TODO REFACTOR THIS TO a separate composer package
+ * @TODO REPLACE THIS WITH PRESONLINKEDIN
  *
  * @author Tim Langley
  **/

--- a/src/php/Lookup/Response/PersonLinkedIn.php
+++ b/src/php/Lookup/Response/PersonLinkedIn.php
@@ -115,4 +115,14 @@ class PersonLinkedIn
         }
         return $arrReturn;
     }
+    public function getEducation()
+    {
+        return $this->_getArrayValue(
+            $this->_arrResponse,
+            [
+                self::KEY_EDUCATION
+            ],
+            []
+        );
+    }
 }

--- a/src/php/Lookup/Response/PersonLinkedIn.php
+++ b/src/php/Lookup/Response/PersonLinkedIn.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * This will soon be the new person response
+ *
+ * Currently we only have this for LinkedIn lookup
+ *
+ * @TODO This should be the default preson response
+ *
+ * @author George Meadows
+ **/
+
+namespace CanddiAi\Lookup\Response;
+
+use CanddiAi\Traits\GetArrayValue as NS_traitArrayValue;
+
+class PersonLinkedIn
+{
+    const KEY_NAME = 'Name';
+    const KEY_FORENAME = 'FirstName';
+    const KEY_MIDDLE = 'MiddleName';
+    const KEY_SURNAME = 'LastName';
+    const KEY_EMAILS = 'EmailAddresses';
+    const KEY_PHONES = 'PhoneNumbers';
+    const KEY_ROLE = 'Employment';
+    const KEY_EDUCATION = 'Education';
+    const KEY_PHOTO = 'Photos';
+    const KEY_SOCIAL = 'SocialMedia';
+
+    use NS_traitArrayValue;
+
+    private $_arrResponse;
+
+    public function __construct(Array $arrResponse)
+    {
+        $this->_arrResponse = $arrResponse;
+    }
+
+    public function getFirstName()
+    {
+        return $this->_getArrayValue(
+            $this->_arrResponse,
+            [
+                self::KEY_NAME,
+                self::KEY_FORENAME
+            ],
+            null
+        );
+    }
+    public function getLastName()
+    {
+        return $this->_getArrayValue(
+            $this->_arrResponse,
+            [
+                self::KEY_NAME,
+                self::KEY_SURNAME
+            ],
+            null
+        );
+    }
+    public function getRole()
+    {
+        $arrRoles =  $this->_getArrayValue(
+            $this->_arrResponse,
+            [
+                self::KEY_ROLE
+            ],
+            []
+        );
+
+        foreach ($arrRoles as $arrRole) {
+            if (isset($arrRole['IsPrimary']) && $arrRole['IsPrimary']) {
+                $itemRole = new Item\Role($arrRole);
+                break;
+            }
+        }
+
+        if (!isset($itemRole)) {
+            if (empty($arrRoles)) {
+                // Got no photos, explicitly return null
+                return null;
+            }
+            // Choose the first photo if we don't have a primary
+            $itemRole = new Item\Role($arrRoles[0]);
+        }
+        return $itemRole;
+    }
+    public function getPhotos()
+    {
+        $arrPhotos  = $this->_getArrayValue(
+            $this->_arrResponse,
+            [
+                self::KEY_PHOTO
+            ],
+            []
+        );
+        $arrReturn  = [];
+        return $arrReturn;
+    }
+    public function getSocialProfiles()
+    {
+        $arrProfiles  = $this->_getArrayValue(
+            $this->_arrResponse,
+            [
+                self::KEY_SOCIAL
+            ],
+            []
+        );
+        $arrReturn  = [];
+
+        //This is a horrible way of returning
+        // too many loops = slow code
+        // @TODO refactor with an Iterator
+        foreach ($arrProfiles as $arrProfile) {
+            $arrReturn[] = new Item\Social($arrProfile);
+        }
+        return $arrReturn;
+    }
+}

--- a/test/php/Lookup/PersonTest.php
+++ b/test/php/Lookup/PersonTest.php
@@ -101,4 +101,53 @@ class PersonTest
             $returnedException->getMessage()
         );
     }
+    public function testLookupLinkedIn()
+    {
+        $strBaseUri = 'baseuri.com';
+        $strAccessToken = md5(1);
+        $strUsername = 'linkedinName';
+        $strAccountURL = 'anAccount';
+        $strCBUrl = 'url';
+        $guidContactId = md5(1);
+        $strURL             = sprintf(Person::c_URL_LinkedIn, $strUsername);
+        $arrQuery           = [
+            'accounturl'    => $strAccountURL,
+            'contactid'     => $guidContactId,
+            'cburl'         => $strCBUrl,
+            'cboptions'     => '{}'
+        ];
+        $companyInstance = Person::getInstance($strBaseUri, $strAccessToken);
+        $mockResponse = \Mockery::mock('GuzzleHttp\Psr7\Response')
+            ->shouldReceive('getStatusCode')
+            ->once()
+            ->withNoArgs()
+            ->andReturn(200)
+            ->shouldReceive('getBody')
+            ->once()
+            ->withNoArgs()
+            ->andReturn('[]')
+            ->mock();
+        $mockGuzzle = \Mockery::mock('GuzzleHttp\Client')
+            ->shouldReceive('request')
+            ->once()
+            ->with(
+                'GET',
+                $strURL,
+                [
+                    'query'         => $arrQuery
+                ]
+            )
+            ->andReturn($mockResponse)
+            ->mock();
+        Person::injectGuzzle($mockGuzzle);
+
+        $actualCompanyResponse = $companyInstance->lookupLinkedIn(
+            $strUsername,
+            $strAccountURL,
+            $guidContactId,
+            $strCBUrl
+        );
+        $expectedCompanyResponse = new Response\PersonLinkedIn([]);
+        $this->assertEquals($expectedCompanyResponse, $actualCompanyResponse);
+    }
 }

--- a/test/php/Lookup/Response/Item/RoleTest.php
+++ b/test/php/Lookup/Response/Item/RoleTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace CanddiAi\Lookup\Response\Item;
+
+class RoleTest
+    extends \CanddiAi\TestCase
+{
+    private $response;
+
+    private function _getTestData()
+    {
+        return [
+            "CompanyName" => "the sequel to the fake company",
+            "StartDate" => "2010-02",
+            "EndDate" => null,
+            "Title" => "ceo",
+            "IsPrimary" => true
+        ];
+    }
+
+    public function testBPrimary()
+    {
+        $response = new Role($this->_getTestData());
+
+        $this->assertTrue($response->bPrimary());
+    }
+
+    public function testGetName()
+    {
+        $response = new Role($this->_getTestData());
+
+        $strExpectedName = "the sequel to the fake company";
+        $strReturnedName = $response->getName();
+
+        $this->assertEquals($strExpectedName, $strReturnedName);
+    }
+
+    public function testGetStartDate()
+    {
+        $response = new Role($this->_getTestData());
+
+        $strExpectedDate = "2010-02";
+        $strReturnedDate = $response->getStartDate();
+
+        $this->assertEquals($strExpectedDate, $strReturnedDate);
+    }
+    public function testGetEndDate()
+    {
+        $response = new Role($this->_getTestData());
+
+        $strExpectedDate = "";
+        $strReturnedDate = $response->getEndDate();
+
+        $this->assertEquals($strExpectedDate, $strReturnedDate);
+    }
+    public function testGetTitle()
+    {
+        $response = new Role($this->_getTestData());
+
+        $strExpectedTitle = "ceo";
+        $strReturnedTitle = $response->getTitle();
+
+        $this->assertEquals($strExpectedTitle, $strReturnedTitle);
+    }
+}

--- a/test/php/Lookup/Response/PersonLinkedIn.php
+++ b/test/php/Lookup/Response/PersonLinkedIn.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace CanddiAi\Lookup\Response;
+
+class PersonTestLinkedIn
+    extends \CanddiAi\TestCase
+{
+
+    private function _getTestData()
+    {
+        return [
+            "EmailAddresses" => [
+                "not-real@fake.com"
+            ],
+            "SocialMedia" => [
+                "Facebook" => [
+                    "url" => "facebook.com/not-real",
+                    "platform" => "Facebook",
+                    "handle" => "not-real"
+                ],
+                "LinkedIn" => [
+                    "url" => "linkedin.com/in/not-real",
+                    "platform" => "LinkedIn",
+                    "handle" => "not-real"
+                ],
+                "Twitter" => [
+                    "url" => "twitter.com/not-real",
+                    "platform" => "Twitter",
+                    "handle" => "not-real"
+                ]
+            ],
+            "PhoneNumbers" => [
+                "+44123456789"
+            ],
+            "Location" => [
+                [
+                    "Address" => [
+                        "PostalCode" => null,
+                        "Line1" => null,
+                        "Line2" => null,
+                        "Country" => "united kingdom",
+                        "Region" => "manchester"
+                    ]
+                ]
+            ],
+            "Name" => [
+                "FirstName" => "not",
+                "LastName" => "real",
+                "MiddleName" => null,
+                "FullName" => "not real"
+            ],
+            "Gender" => "male",
+            "Employment" => [
+                [
+                    "CompanyName" => "the fake company",
+                    "StartDate" => "2007-06",
+                    "EndDate" => "2007-10",
+                    "Title" => "venture capitalist",
+                    "IsPrimary" => false
+                ],
+                [
+                    "CompanyName" => "the sequel to the fake company",
+                    "StartDate" => "2010-02",
+                    "EndDate" => null,
+                    "Title" => "ceo",
+                    "IsPrimary" => true
+                ]
+            ],
+            "Education" => [
+                [
+                    "Name" => "the fake school",
+                    "StartDate" => null,
+                    "EndDate" => "1996"
+                ]
+            ]
+        ];
+    }
+    public function testGetFirstName()
+    {
+        $testData = $this->_getTestData();
+        $response = new PersonLinkedIn($testData);
+
+        $strExpectedFirstName = "not";
+        $strReturnedFirstName = $response->getFirstName();
+
+        $this->assertEquals($strExpectedFirstName, $strReturnedFirstName);
+
+        // Test to make sure it returns null when there's no firstname
+        unset($testData["Name"]["FirstName"]);
+        $response = new PersonLinkedIn($testData);
+
+        $this->assertEquals(null, $response->getFirstName());
+
+        // Test for if the ContactInfo field doesn't exist
+        unset($testData["Name"]);
+        $response = new PersonLinkedIn($testData);
+
+        $this->assertEquals(null, $response->getFirstName());
+    }
+    public function testGetLastName()
+    {
+        $testData = $this->_getTestData();
+        $response = new PersonLinkedIn($testData);
+
+        $strExpectedLastName = "real";
+        $strReturnedLastName = $response->getLastName();
+
+        $this->assertEquals($strExpectedLastName, $strReturnedLastName);
+
+        // Test to make sure it returns null when there's no LastName
+        unset($testData["Name"]["LastName"]);
+        $response = new PersonLinkedIn($testData);
+
+        $this->assertEquals(null, $response->getLastName());
+
+        // Test for if the ContactInfo field doesn't exist
+        unset($testData["Name"]);
+        $response = new PersonLinkedIn($testData);
+
+        $this->assertEquals(null, $response->getFirstName());
+    }
+
+    public function testGetRole()
+    {
+        $testData = $this->_getTestData();
+        $response = new PersonLinkedIn($testData);
+        $itemRole = $response->getRole();
+
+        $this->assertTrue($itemRole->bPrimary());
+        $this->assertEquals('ceo', $itemRole->getTitle());
+        $this->assertEquals('the sequel to the fake company', $itemRole->getName());
+        $this->assertEquals('2010-02', $itemRole->getStartDate());
+        $this->assertEquals('', $itemRole->getEndDate());
+
+        unset($testData['Employment']);
+        $response = new PersonLinkedIn($testData);
+
+        $this->assertEquals(null, $response->getRole());
+    }
+    public function testGetSocialProfiles()
+    {
+        $response = new PersonLinkedIn($this->_getTestData());
+
+        $arrProfiles = $response->getSocialProfiles();
+
+        $this->assertTrue(is_array($arrProfiles));
+    }
+    public function testGetPhotos()
+    {
+        $response = new PersonLinkedIn($this->_getTestData());
+
+        $arrPhotos = $response->getPhotos();
+
+        $this->assertTrue(is_array($arrPhotos));
+    }
+    public function testGetEducation()
+    {
+        $testData = $this->_getTestData();
+        $response = new PersonLinkedIn($testData);
+
+        $arrEducation = $response->getEducation();
+
+        $this->assertTrue(is_array($arrEducation));
+
+        $expectedResponse = $testData['Education'];
+
+        $this->assertEquals($expectedResponse, $arrEducation);
+    }
+}


### PR DESCRIPTION
TODO: Still need to update serverless_canddi_ip endpoint so that we return IsPrimary on employment

Added handling and calling of the new person linkedin endpoint

This response is quite different from our normal person response, so a new one has been made here

Eventually, this new response will completely replace the old response