### PR TITLE
CS-12396 - Getter for company field

### DIFF
--- a/src/php/Lookup/Response/Person.php
+++ b/src/php/Lookup/Response/Person.php
@@ -9,6 +9,7 @@
 namespace CanddiAi\Lookup\Response;
 
 use CanddiAi\Traits\GetArrayValue as NS_traitArrayValue;
+use CanddiAi\Lookup\Response\Company\Company as ResponseCompany;
 
 class Person
 {

--- a/src/php/Lookup/Response/Person.php
+++ b/src/php/Lookup/Response/Person.php
@@ -32,8 +32,6 @@ class Person
     {
         if(array_key_exists('Person', $arrResponse)) {
             $this->_arrResponse = $arrResponse['Person'];
-        } else {
-            $this->_arrResponse = $arrResponse;
         }
     }
 

--- a/src/php/Lookup/Response/Person.php
+++ b/src/php/Lookup/Response/Person.php
@@ -27,12 +27,25 @@ class Person
     use NS_traitArrayValue;
 
     private $_arrResponse;
+    private $_mdlCompanyResponse;
 
     public function __construct(Array $arrResponse)
     {
+        $this->_arrResponse = [];
         if(array_key_exists('Person', $arrResponse)) {
             $this->_arrResponse = $arrResponse['Person'];
         }
+
+        if(array_key_exists('Company', $arrResponse)) {
+            $this->_mdlCompanyResponse = new ResponseCompany($arrResponse['Company']);
+        } else {
+            $this->_mdlCompanyResponse = new ResponseCompany([]);
+        }
+    }
+
+    public function getCompany()
+    {
+        return $this->_mdlCompanyResponse;
     }
 
     public function getEmailAddresses()

--- a/test/php/Lookup/Response/PersonTest.php
+++ b/test/php/Lookup/Response/PersonTest.php
@@ -257,14 +257,15 @@ class PersonTestLinkedIn
 
         $this->assertEquals($expectedResponse, $arrPhones);
     }
-    public function testNoPersonField() {
-        $arrTestData = $this->_getTestData()['Person'];
+    public function testGetCompany()
+    {
+        $testData = $this->_getTestData();
+        $response = new Person($testData);
 
-        $response = new Person($arrTestData);
-
-        $expectedResponse = $arrTestData[Person::KEY_PHONES];
-        $actualResponse = $response->getPhoneNumbers();
+        $expectedResponse = new Company\Company($testData['Company']);
+        $actualResponse = $response->getCompany();
 
         $this->assertEquals($expectedResponse, $actualResponse);
+
     }
 }


### PR DESCRIPTION
On lookupEmail, we now return a company field, so this PR is to add a getter for it

so that we can use it in other repos such as canddi


**also removed using the whole response body as the person response** as this was temporary, no need for this now