### PR TITLE
Mg gds 9518 - Add methods for ISP or mobile ISP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name"                              : "canddi/CANDDi_ai",
+    "name"                              : "canddi/canddi_ai",
     "description"                       : "CANDDi AI repo",
     "license"                           : "proprietary",
     "minimum-stability"                 : "dev",

--- a/src/php/Lookup/Response/Company.php
+++ b/src/php/Lookup/Response/Company.php
@@ -24,6 +24,9 @@ class Company
     const KEY_TYPE      = 'Type';
     const KEY_REPROCESS = 'Reprocess';
 
+    const TYPE_ISP          = 1;
+    const TYPE_MOBILE_ISP   = 2;
+
     use NS_traitArrayValue;
 
     private $_arrResponse;
@@ -89,13 +92,25 @@ class Company
         );
     }
     public function bIsISP() {
-        $intType = $this->_getArrayValue(
-            $this->_arrResponse,
-            [self::KEY_TYPE],
-            null
-        );
+        $intType = $this->getType();
 
-        if ($intType && $intType === 1) {
+        if (
+            !is_null($intType) &&
+            $intType === self::TYPE_ISP
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function bIsMobileISP() {
+        $intType = $this->getType();
+
+        if (
+            !is_null($intType) &&
+            $intType === self::TYPE_MOBILE_ISP
+        ) {
             return true;
         }
 

--- a/test/php/Lookup/AddressTest.php
+++ b/test/php/Lookup/AddressTest.php
@@ -35,7 +35,7 @@ class AddressTest
             ->shouldReceive('getBody')
             ->once()
             ->withNoArgs()
-            ->andReturn(JSON_encode($arrAddressData))
+            ->andReturn($this->_mockResponseBody(JSON_encode($arrAddressData)))
             ->mock();
         $mockGuzzle = \Mockery::mock('GuzzleHttp\Client')
             ->shouldReceive('request')

--- a/test/php/Lookup/CompanyTest.php
+++ b/test/php/Lookup/CompanyTest.php
@@ -29,7 +29,7 @@ class CompanyTest
             ->shouldReceive('getBody')
             ->once()
             ->withNoArgs()
-            ->andReturn('[]')
+            ->andReturn($this->_mockResponseBody('[]'))
             ->mock();
         $mockGuzzle = \Mockery::mock('GuzzleHttp\Client')
             ->shouldReceive('request')
@@ -76,7 +76,7 @@ class CompanyTest
             ->shouldReceive('getBody')
             ->once()
             ->withNoArgs()
-            ->andReturn('[]')
+            ->andReturn($this->_mockResponseBody('[]'))
             ->mock();
         $mockGuzzle = \Mockery::mock('GuzzleHttp\Client')
             ->shouldReceive('request')
@@ -117,7 +117,7 @@ class CompanyTest
             ->shouldReceive('getBody')
             ->once()
             ->withNoArgs()
-            ->andReturn('[]')
+            ->andReturn($this->_mockResponseBody('[]'))
             ->mock();
         $mockGuzzle = \Mockery::mock('GuzzleHttp\Client')
             ->shouldReceive('request')
@@ -160,7 +160,7 @@ class CompanyTest
             ->shouldReceive('getBody')
             ->once()
             ->withNoArgs()
-            ->andReturn('[]')
+            ->andReturn($this->_mockResponseBody('[]'))
             ->mock();
         $mockGuzzle = \Mockery::mock('GuzzleHttp\Client')
             ->shouldReceive('request')
@@ -275,9 +275,9 @@ class CompanyTest
             ->shouldReceive('getBody')
             ->once()
             ->withNoArgs()
-            ->andReturn("{
+            ->andReturn($this->_mockResponseBody("{
                 \"Reprocess\" : true
-            }")
+            }"))
             ->mock();
         $mockGuzzle = \Mockery::mock('GuzzleHttp\Client')
             ->shouldReceive('request')
@@ -321,7 +321,7 @@ class CompanyTest
             ->shouldReceive('getBody')
             ->once()
             ->withNoArgs()
-            ->andReturn("{
+            ->andReturn($this->_mockResponseBody("{
                 \"Hostname\": \"orckid.co.uk\",
                 \"Type\": 0,
                 \"IP\": {
@@ -344,7 +344,7 @@ class CompanyTest
                     \"Region\": \"ENG\"
                   }
                 }
-              }")
+              }"))
             ->mock();
         $mockGuzzle = \Mockery::mock('GuzzleHttp\Client')
             ->shouldReceive('request')
@@ -413,7 +413,7 @@ class CompanyTest
             ->shouldReceive('getBody')
             ->once()
             ->withNoArgs()
-            ->andReturn("{
+            ->andReturn($this->_mockResponseBody("{
                 \"Hostname\": \"orckid.co.uk\",
                 \"Type\": 0,
                 \"Company\": {
@@ -586,7 +586,7 @@ class CompanyTest
                     \"Region\": \"ENG\"
                   }
                 }
-              }")
+              }"))
             ->mock();
         $mockGuzzle = \Mockery::mock('GuzzleHttp\Client')
             ->shouldReceive('request')
@@ -803,9 +803,9 @@ class CompanyTest
             ->shouldReceive('getBody')
             ->once()
             ->withNoArgs()
-            ->andReturn("{
+            ->andReturn($this->_mockResponseBody("{
                 \"Reprocess\" : true
-            }")
+            }"))
             ->mock();
         $mockGuzzle = \Mockery::mock('GuzzleHttp\Client')
             ->shouldReceive('request')
@@ -851,9 +851,9 @@ class CompanyTest
             ->shouldReceive('getBody')
             ->once()
             ->withNoArgs()
-            ->andReturn("{
+            ->andReturn($this->_mockResponseBody("{
                 \"Reprocess\" : true
-            }")
+            }"))
             ->mock();
         $mockGuzzle = \Mockery::mock('GuzzleHttp\Client')
             ->shouldReceive('request')
@@ -897,7 +897,7 @@ class CompanyTest
             ->shouldReceive('getBody')
             ->once()
             ->withNoArgs()
-            ->andReturn("{
+            ->andReturn($this->_mockResponseBody("{
                 \"Company\": {
                     \"VAT\": \"GB107133945\",
                     \"Email\": \"hello@canddi.com\",
@@ -1049,7 +1049,7 @@ class CompanyTest
                     \"Hostname\": \"canddi.com\"
                 },
                 \"Hostname\": \"canddi.com\"
-            }")
+            }"))
             ->mock();
         $mockGuzzle = \Mockery::mock('GuzzleHttp\Client')
             ->shouldReceive('request')

--- a/test/php/Lookup/NormalizeNameTest.php
+++ b/test/php/Lookup/NormalizeNameTest.php
@@ -38,7 +38,7 @@ class NormalizeNameTest
             ->shouldReceive('getBody')
             ->once()
             ->withNoArgs()
-            ->andReturn(JSON_encode($responseBody))
+            ->andReturn($this->_mockResponseBody(JSON_encode($responseBody)))
             ->mock();
 
         $mockGuzzle = \Mockery::mock('GuzzleHttp\Client')
@@ -71,18 +71,6 @@ class NormalizeNameTest
         $strURL = sprintf(NormalizeName::c_URL_NORMALIZE, $strName);
 
         $normalizeNameInstance = NormalizeName::getInstance($strBaseUri, $strAccessToken);
-
-        $responseBody = [
-            "status" => "200",
-            "requestId" => "20072030-ba42-4b6b-982e-2b0bc3ce923a",
-            "likelihood" => 1,
-            "nameDetails" => [
-                "givenName" => "Logan",
-                "familyName" => "White",
-                "fullName" => "Logan White"
-            ],
-            "region" => "USA"
-        ];
 
         $this->setExpectedException(\Exception::class, 'NotFound: No names found for fakename');
 

--- a/test/php/Lookup/PersonTest.php
+++ b/test/php/Lookup/PersonTest.php
@@ -31,7 +31,7 @@ class PersonTest
             ->shouldReceive('getBody')
             ->once()
             ->withNoArgs()
-            ->andReturn('[]')
+            ->andReturn($this->_mockResponseBody('[]'))
             ->mock();
         $mockGuzzle = \Mockery::mock('GuzzleHttp\Client')
             ->shouldReceive('request')
@@ -77,7 +77,7 @@ class PersonTest
             ->shouldReceive('getBody')
             ->once()
             ->withNoArgs()
-            ->andReturn('[]')
+            ->andReturn($this->_mockResponseBody('[]'))
             ->mock();
         $mockGuzzle = \Mockery::mock('GuzzleHttp\Client')
             ->shouldReceive('request')
@@ -179,7 +179,7 @@ class PersonTest
             ->shouldReceive('getBody')
             ->once()
             ->withNoArgs()
-            ->andReturn('[]')
+            ->andReturn($this->_mockResponseBody('[]'))
             ->mock();
         $mockGuzzle = \Mockery::mock('GuzzleHttp\Client')
             ->shouldReceive('request')
@@ -228,7 +228,7 @@ class PersonTest
             ->shouldReceive('getBody')
             ->once()
             ->withNoArgs()
-            ->andReturn("{
+            ->andReturn($this->_mockResponseBody("{
               \"Person\": {
                   \"Name\": {
                       \"FirstName\": \"Tim\",
@@ -396,7 +396,7 @@ class PersonTest
                       }
                   ]
               }
-          }")
+          }"))
             ->mock();
         $mockGuzzle = \Mockery::mock('GuzzleHttp\Client')
             ->shouldReceive('request')
@@ -613,9 +613,9 @@ class PersonTest
             ->shouldReceive('getBody')
             ->once()
             ->withNoArgs()
-            ->andReturn("{
+            ->andReturn($this->_mockResponseBody("{
                 \"Reprocess\" : true
-            }")
+            }"))
             ->mock();
         $mockGuzzle = \Mockery::mock('GuzzleHttp\Client')
             ->shouldReceive('request')
@@ -659,7 +659,7 @@ class PersonTest
             ->shouldReceive('getBody')
             ->once()
             ->withNoArgs()
-            ->andReturn("{
+            ->andReturn($this->_mockResponseBody("{
                 \"Hostname\": \"orckid.co.uk\",
                 \"Type\": 0,
                 \"Company\": {
@@ -836,7 +836,7 @@ class PersonTest
                       \"YearsExperience\": 25
                     }
                   ]
-              }")
+              }"))
             ->mock();
         $mockGuzzle = \Mockery::mock('GuzzleHttp\Client')
             ->shouldReceive('request')
@@ -1061,7 +1061,7 @@ class PersonTest
             ->shouldReceive('getBody')
             ->once()
             ->withNoArgs()
-            ->andReturn("{
+            ->andReturn($this->_mockResponseBody("{
                 \"Hostname\": \"orckid.co.uk\",
                 \"Type\": 0,
                 \"Company\": {
@@ -1257,7 +1257,7 @@ class PersonTest
                     ],
                     \"Email\": \"tim\"
                 }
-              }")
+              }"))
             ->mock();
         $mockGuzzle = \Mockery::mock('GuzzleHttp\Client')
             ->shouldReceive('request')

--- a/test/php/Lookup/Response/CompanyTest.php
+++ b/test/php/Lookup/Response/CompanyTest.php
@@ -150,8 +150,45 @@ class CompanyTest
             $respCompany->bIsISP()
         );
 
+        $this->assertEquals(
+            false,
+            $respCompany->bIsMobileISP()
+        );
+
         $this->assertTrue(
             $respCompany->bIsReprocessing()
+        );
+    }
+    public function testCheckingISPTypes()
+    {
+        $arrTestData = $this->_getTestData();
+
+        $arrTestData[Company::KEY_TYPE] = Company::TYPE_ISP;
+
+        $respCompany = new Company($arrTestData);
+
+        $this->assertEquals(
+            true,
+            $respCompany->bIsISP()
+        );
+
+        $this->assertEquals(
+            false,
+            $respCompany->bIsMobileISP()
+        );
+
+        $arrTestData[Company::KEY_TYPE] = Company::TYPE_MOBILE_ISP;
+
+        $respCompany = new Company($arrTestData);
+
+        $this->assertEquals(
+            true,
+            $respCompany->bIsMobileISP()
+        );
+
+        $this->assertEquals(
+            false,
+            $respCompany->bIsISP()
         );
     }
     public function testDefaultProcessing()

--- a/test/php/Lookup/UserAgentTest.php
+++ b/test/php/Lookup/UserAgentTest.php
@@ -28,8 +28,6 @@ class UserAgentTest
         $strBaseUri = 'baseuri.com';
         $strAccessToken = md5(1);
         $strUserAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.86 Safari/537.36';
-        $strAccountURL = 'anAccount';
-        $guidContactId = md5(1);
         $arrQuery = [
             'accounturl' => null,
             'contactid' => null
@@ -44,7 +42,7 @@ class UserAgentTest
             ->shouldReceive('getBody')
             ->once()
             ->withNoArgs()
-            ->andReturn(JSON_encode($arrUserAgentData))
+            ->andReturn($this->_mockResponseBody(JSON_encode($arrUserAgentData)))
             ->mock();
         $mockGuzzle = \Mockery::mock('GuzzleHttp\Client')
             ->shouldReceive('request')

--- a/test/php/TestCase.php
+++ b/test/php/TestCase.php
@@ -91,4 +91,12 @@ class TestCase extends \Zend_Test_PHPUnit_ControllerTestCase
         $refMethod->setAccessible(true);
         return $refMethod->invoke($obj, $arg, $arg2);
     }
+
+    protected function _mockResponseBody(string $strBody)
+    {
+        return \Mockery::mock('Psr\Http\Message\StreamInterface')
+            ->shouldReceive('__toString')
+            ->andReturn($strBody)
+            ->mock();
+    }
 }


### PR DESCRIPTION
[GDS-9518](https://canddi.atlassian.net/browse/GDS-9518)

- Had to fix a bunch of tests that were expecting a guzzle stream response but were strings
- Added bIsMobileISP
- We already had bIsISP, getIsCloudHost

[GDS-9518]: https://canddi.atlassian.net/browse/GDS-9518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ