### PR TITLE
Mg gds 14774 - Laravel 11 upgrade (Allow any guzzle 7)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability"                 : "dev",
     "prefer-stable"                     : true,
     "require"                           : {
-        "guzzlehttp/guzzle"             : "7.4.5"
+        "guzzlehttp/guzzle"             : "^7"
     },
     "require-dev"                       : {
         "fzaninotto/faker"              : "1.7.1",


### PR DESCRIPTION
This library shouldn't really have so much control about exact versions of guzzle, makes updating this within canddi annoying (as in this case) and in theory should work with any version that doens't jump majors